### PR TITLE
Add Threat Bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [YARA](https://github.com/virustotal/yara) - The pattern matching swiss knife
 - [Intel Owl](https://github.com/intelowlproject/IntelOwl) - An Open Source Intelligence, or OSINT solution to get threat intelligence data about a specific file, an IP or a domain from a single API at scale.
 - [Capa](https://github.com/fireeye/capa) - An open-source tool to identify capabilities in executable files.
+- [Threat Bus](https://github.com/tenzir/threatbus) - Threat intelligence dissemination layer to connect security tools through a distributed publish/subscribe message broker.
 
 #### Alerting Engine
 


### PR DESCRIPTION
This PR adds our threat intelligence broker [Threat Bus](https://github.com/tenzir/threatbus) to the list.