### PR TITLE
Add ThreatJammer.com to the Threat Intel list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 - [Netresec's PCAP repo list](https://www.netresec.com/?page=PcapFiles) - A list of public packet capture repositories, which are freely available on the Internet.
 - [PCAP-ATTACK](https://github.com/sbousseaden/PCAP-ATTACK) - A repo of PCAP samples for different ATT&CK techniques.
 - [EVTX-ATTACK-SAMPLES](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES) - A repo of Windows event samples (EVTX) associated with ATT&CK techniques ([EVTX-ATT&CK Sheet](https://docs.google.com/spreadsheets/d/12V5T9j6Fi3JSmMpAsMwovnWqRFKzzI9l2iXS5dEsnrs/edit#gid=164587082)).
+- [Threat Jammer](https://threatjammer.com) - REST API service that allows developers, security engineers, and other IT professionals to access curated threat intelligence data from a variety of sources.
 
 
 ### Resources


### PR DESCRIPTION
I hope this new service is valuable to the threat intel community and security professionals.

I have added the service at the end of the list. I was not able to figure out if there was any specific sorting (lexicographic or newer entries at the bottom). Sorry if I was wrong.