### PR TITLE
Fix dead Research paper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     - [DNS](#dns)
     - [Fingerprinting](#fingerprinting)
     - [Data Science](#data-science)
-    - [Research Papers](research-papers)
+    - [Research Papers](#research-papers)
     - [Blogs](#blogs)
     - [Related Awesome Lists](#related-awesome-lists)
   - 🎙️ [Podcasts](#podcasts)


### PR DESCRIPTION
Currenly this link goes to `https://github.com/0x4D31/awesome-threat-detection/blob/master/research-papers` which does not exist. Adding `#` like the rest of links on the list to fix this.

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/42276283/223870535-2c69fba8-b00f-42f1-9fde-f8bcb11e9387.png">
