### PR TITLE
Add new resource to Labs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@
 
 ## Labs
 
+- [LabEx](https://labex.io/skilltrees/cybersecurity) - Hands-on labs for cyber security, covering tools like Nmap, Wireshark, Kali, and more.
 - [DetectionLab](https://github.com/clong/DetectionLab/) - Vagrant & Packer scripts to build a lab environment complete with security tooling and logging best practices.
 - [Splunk Boss of the SOC](https://bots.splunk.com/) - Hands-on workshops and challenges to practice threat hunting using the BOTS and other datasets.
 - [HELK](https://github.com/Cyb3rWard0g/HELK) - A Hunting ELK (Elasticsearch, Logstash, Kibana) with advanced analytic capabilities.


### PR DESCRIPTION
Add LabEx cybersecurity labs to Labs section.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.