### PR TITLE
Add Whisper - a free threat intelligence API for threat detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - [Brosquery](https://github.com/jandre/brosquery) - A module for osquery to load Bro logs into tables
 - [DeepBlueCLI](https://github.com/sans-blue-team/DeepBlueCLI) - A PowerShell Module for Hunt Teaming via Windows Event Logs
 - [Uncoder](https://uncoder.io) - An online translator for SIEM saved searches, filters, queries, API requests, correlation and Sigma rules
+- [Whisper](https://whisper.security) - Real-time graph intelligence platform that correlates 45 billion internet infrastructure data points. Built by former ICANN Board Director Kaveh Ranjbar and Soroush Rafiee Rad (double PhD in Math/InfoSec). Free API available at developer.whisper.security.
 - [CimSweep](https://github.com/PowerShellMafia/CimSweep) - A suite of CIM/WMI-based tools that enable the ability to perform incident response and hunting operations remotely across all versions of Windows
 - [Dispatch](https://github.com/Netflix/dispatch) - An open-source crisis management orchestration framework
 - [EQL](https://github.com/endgameinc/eql) - Event Query Language


### PR DESCRIPTION
Hi there,

I'd like to suggest adding Whisper to your list of threat detection tools.

It's a new real-time graph intelligence platform built by Kaveh Ranjbar (former ICANN Board Director, ran one of the 13 root servers) and Soroush Rafiee Rad (double PhD in Math/InfoSec). They wanted to build something to help threat hunters and detection engineers get better infrastructure context.

Whisper has a free API that lets you query their graph of 45 billion correlated internet data points. It's designed to help with threat hunting, detection engineering, and understanding infrastructure relationships.

We'd love to get feedback from the threat detection community on how we can make it more useful. You can try out the free API here: https://developer.whisper.security

Thanks!