### PR TITLE
Add sigma-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 - [GCP Security Analytics](https://github.com/GoogleCloudPlatform/security-analytics) - Community Security Analytics provides a set of community-driven audit & threat queries for Google Cloud.
 - [ThreatHunter-Playbook](https://github.com/OTRF/ThreatHunter-Playbook) - A community-driven, open-source project to share detection logic, adversary tradecraft and resources to make detection development more efficient.
 - [Sublime Detection Rules](https://github.com/sublime-security/sublime-rules) - Email attack detection, response, and hunting rules.
+- [sigma-check](https://github.com/0xPersist/sigma-check) - A Sigma rule validator, linter, and tester for checking rules against sample log events.
 
 ## Dataset
 


### PR DESCRIPTION
Adds sigma-check to Detection Rules: an open source Sigma rule validator, linter, and tester that checks rules against sample log events before deployment. Follows the entry format, checked for duplicates.