### PR TITLE
Add ransomware incident response guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@
 - [Netcap](https://github.com/dreadl0ck/netcap) - A framework for secure and scalable network traffic analysis
 - [Arkime](https://github.com/arkime/arkime)) - A large scale and open source full packet capture and search tool
 - [Stenographer](https://github.com/google/stenographer) - A full-packet-capture tool
-- [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - An open-source DDoS traffic monitor for Linux with per-packet inspection, attack classification, PCAP capture, and IOC pattern matching
+- [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Lightweight network traffic monitor with adaptive baseline detection for volumetric DDoS attacks, supporting raw packet capture, sFlow, NetFlow, and IPFIX.
 
 #### Fingerprinting Tools
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 - [Netcap](https://github.com/dreadl0ck/netcap) - A framework for secure and scalable network traffic analysis
 - [Arkime](https://github.com/arkime/arkime)) - A large scale and open source full packet capture and search tool
 - [Stenographer](https://github.com/google/stenographer) - A full-packet-capture tool
+- [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - An open-source DDoS traffic monitor for Linux with per-packet inspection, attack classification, PCAP capture, and IOC pattern matching
 
 #### Fingerprinting Tools
 


### PR DESCRIPTION
Adds a practical incident response guide covering the first 24 hours after a ransomware attack. Disclosure: This is published by TrazTech, a security consultancy I am affiliated with.